### PR TITLE
大佬，发现您的项目引入了ch.qos.logback:logback-classic@1.1.9组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>cool.lazy-cat</groupId>
@@ -22,7 +20,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.1.9</version>
+            <version>1.2.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：QOS.ch Logback SocketServer和ServerSocketReceiver组件权限提升漏洞
缺陷组件：ch.qos.logback:logback-classic@1.1.9
漏洞编号：CVE-2017-5929
漏洞描述：QOS.ch Logback是一套使用Java编写的日志框架。SocketServer和ServerSocketReceiver都是其中的调试模块。

QOS.ch Logback 1.1.10之前版本中的SocketServer和ServerSocketReceiver组件存在安全漏洞。攻击者可利用该漏洞获取提升的权限。
国家漏洞库信息：https://www.cnvd.org.cn/flaw/show/CNVD-2017-04335
影响范围：[0.3, 1.2.0)
最小修复版本：1.2.0
缺陷组件引入路径：cool.lazy-cat:combiner@1.0-SNAPSHOT->ch.qos.logback:logback-classic@1.1.9
```
另外我运行这个项目时，IDE的安全插件提示还有1个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p69874